### PR TITLE
Replace unsupported flag in script dependencies installation command

### DIFF
--- a/.github/workflows/find-workflows-awaiting.yml
+++ b/.github/workflows/find-workflows-awaiting.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "${{ env.SCRIPT_PATH }}"
-          poetry install --no-dev --no-root
+          poetry install --no-root --only main
 
       - name: Check for workflows awaiting approval
         env:


### PR DESCRIPTION
[**workflowsawaiting**](https://github.com/per1234/workflowsawaiting) has several Python package dependencies which must be installed in order to use the script. The dependencies are managed using the [**Poetry**](https://python-poetry.org/) tool.

In addition to the script dependencies, various Python packages are used in the infrastructure of the **workflowsawaiting** project (development dependencies), so those are also specified as dependencies of the project. For the sake of efficiency, the dependencies installation command in the "Find Workflows Awaiting Approval" workflow is configured to only install the script dependencies. This is possible because the development dependencies are organized into a dedicated `dev` [dependencies group](https://python-poetry.org/docs/managing-dependencies/#dependency-groups).

Previously, the [`--no-dev` flag](https://python-poetry.org/docs/1.8/cli/#options-2) was used in the [`poetry install`](https://python-poetry.org/docs/cli/#install) command to accomplish this. However, Poetry has migrated to a more flexible system where dependencies can be organized into any number of arbitrary groups, and the installation of the groups controlled. For this reason the `dev` group-specific `--no-dev` flag has been replaced by general purpose flags that can be used with any group. 

The previous dependencies installation command now fails when used with modern versions of Poetry:

```
The option "--no-dev" does not exist
```

The flag is hereby replaced with the modern equivalent [`--only main`](https://python-poetry.org/docs/cli/#options-8) (the [`main` group](https://python-poetry.org/docs/managing-dependencies/#dependency-groups) is the script dependencies).