### PR TITLE
Manage Python version used to run script via "Find Workflows Awaiting Approval" workflow

### DIFF
--- a/.github/workflows/find-workflows-awaiting.yml
+++ b/.github/workflows/find-workflows-awaiting.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install Python
         uses: actions/setup-python@v5
+        with:
+          python-version-file: ${{ env.SCRIPT_PATH }}/pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry


### PR DESCRIPTION
Previously, the workflow used whichever version of Python was provided as default by the "actions/setup-python" action. That version can change at any time, which could result in instability.

The version of Python used by the workflow is now controlled by the version specified in the pyproject.toml file of the workflowsawaiting project:

https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-file-input