### PR TITLE
Add configuration file to workflow paths filter

### DIFF
--- a/.github/workflows/find-workflows-awaiting.yml
+++ b/.github/workflows/find-workflows-awaiting.yml
@@ -5,9 +5,11 @@ on:
   push:
     paths:
       - ".github/workflows/find-workflows-awaiting.ya?ml"
+      - "configuration.yml"
   pull_request:
     paths:
       - ".github/workflows/find-workflows-awaiting.ya?ml"
+      - "configuration.yml"
   schedule:
     # Run at the minimum interval allowed by GitHub Actions.
     - cron: "*/5 * * * *"


### PR DESCRIPTION
In order to provide self-validation, the "Find Workflows Awaiting Approval" GitHub Actions workflow is [configured](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) to be triggered when a commit is pushed that modifies relevant files.

The configuration file is one of these files, yet previously the workflow was not configured to trigger on modifications to that file.