### PR TITLE
Remove deleted organization from configuration file

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -4,4 +4,3 @@
 - owner: arduino
 - owner: Arduino-CI
 - owner: arduino-libraries
-- owner: snowfox-project


### PR DESCRIPTION
The "snowfox-project" GitHub organization has been deleted. This caused the script runs to fail:

```
fastcore.net.HTTP404NotFoundError: HTTP Error 404: Not Found
====Error Body====
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest",
  "status": "404"
}
```