### PR TITLE
Ignore arduino/docs-content repository

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -2,5 +2,8 @@
 
 - owner: 107-systems
 - owner: arduino
+- owner: arduino
+  repo: docs-content
+  action: ignore
 - owner: Arduino-CI
 - owner: arduino-libraries


### PR DESCRIPTION
I don't have any involvement in the maintenance of this repository, and so there is no reason why I should get notifications of workflows awaiting approval in this repository.

A configuration item is hereby added to cause the workflowsawaiting tool to ignore the arduino/docs-content repository.